### PR TITLE
Add full-bleed preview capability

### DIFF
--- a/apiExamples/fullBleed.html
+++ b/apiExamples/fullBleed.html
@@ -16,8 +16,9 @@
       <img style="object-fit: cover;" src="https://picsum.photos/1000/480?random=5" alt="Random image 5">
     </div>
   </auro-slideshow>
+  <!-- For demo purposes only -->
   <style>
     body {
-        overflow-x: hidden;
+      overflow-x: hidden;
     }
   </style>

--- a/apiExamples/fullBleed.html
+++ b/apiExamples/fullBleed.html
@@ -1,0 +1,24 @@
+
+  <auro-slideshow fullBleed autoplay pagination navigation loop>
+    <div style="height: 480px">
+      <img style="object-fit: cover;" src="https://picsum.photos/1000/480?random=1" alt="Random image 1">
+    </div>
+    <div style="height: 480px">
+      <img style="object-fit: cover;" src="https://picsum.photos/1000/480?random=2" alt="Random image 2">
+    </div>
+    <div style="height: 480px">
+      <img style="object-fit: cover;" src="https://picsum.photos/1000/480?random=3" alt="Random image 3">
+    </div>
+    <div style="height: 480px">
+      <img style="object-fit: cover;" src="https://picsum.photos/1000/480?random=4" alt="Random image 4">
+    </div>
+    <div style="height: 480px">
+      <img style="object-fit: cover;" src="https://picsum.photos/1000/480?random=5" alt="Random image 5">
+    </div>
+  </auro-slideshow>
+  <style>
+    .exampleWrapper:last-of-type {
+        overflow-x: hidden;
+        background-color: #b4eff9;
+    }
+  </style>

--- a/apiExamples/fullBleed.html
+++ b/apiExamples/fullBleed.html
@@ -17,8 +17,7 @@
     </div>
   </auro-slideshow>
   <style>
-    .exampleWrapper:last-of-type {
+    body {
         overflow-x: hidden;
-        background-color: #b4eff9;
     }
   </style>

--- a/apiExamples/fullBleedAutoScroll.html
+++ b/apiExamples/fullBleedAutoScroll.html
@@ -1,0 +1,18 @@
+
+  <auro-slideshow fullBleed navigation autoscroll playOnInit loop>
+    <div style="height: 480px; max-width: 400px;">
+      <img style="object-fit: cover;" src="https://picsum.photos/400/480?random=1" alt="Random image 1">
+    </div>
+    <div style="height: 480px; max-width: 400px;">
+      <img style="object-fit: cover;" src="https://picsum.photos/400/480?random=2" alt="Random image 2">
+    </div>
+    <div style="height: 480px; max-width: 400px;">
+      <img style="object-fit: cover;" src="https://picsum.photos/400/480?random=3" alt="Random image 3">
+    </div>
+    <div style="height: 480px; max-width: 400px;">
+      <img style="object-fit: cover;" src="https://picsum.photos/400/480?random=4" alt="Random image 4">
+    </div>
+    <div style="height: 480px; max-width: 400px;">
+      <img style="object-fit: cover;" src="https://picsum.photos/400/480?random=5" alt="Random image 5">
+    </div> 
+  </auro-slideshow>

--- a/apiExamples/fullBleedAutoScroll.html
+++ b/apiExamples/fullBleedAutoScroll.html
@@ -16,3 +16,9 @@
       <img style="object-fit: cover;" src="https://picsum.photos/400/480?random=5" alt="Random image 5">
     </div> 
   </auro-slideshow>
+  <!-- For demo purposes only -->
+  <style>
+    body {
+      overflow-x: hidden;
+    }
+  </style>

--- a/docs/api.md
+++ b/docs/api.md
@@ -1,5 +1,11 @@
 # auro-slideshow
 
+## Attributes
+
+| Attribute   | Description                                      |
+|-------------|--------------------------------------------------|
+| `fullBleed` | If set, the slideshow will take up the width of its parent container showing previous and next slides. **Note:** a parent container must have `overflow-x: hidden` to prevent horizontal scrolling. |
+
 ## Properties
 
 | Property      | Attribute     | Type      | Default           | Description                                      |

--- a/docs/partials/api.md
+++ b/docs/partials/api.md
@@ -191,7 +191,7 @@ To set a custom aria-label for the play/pause button, pass in new values to the 
 
 To enable the slideshow to show a preview of the previous and next slides, use the `fullBleed` attribute. This will unhide the overflow of the view area. 
 
-**Note:** To use this properly, a parent container MUST have `overflow-x: hidden` to prevent horizontal scrolling on the page. 
+**Note:** To use this properly, a parent container MUST have `overflow-x: hidden` to prevent horizontal scrolling on the page. It is not recommended to put `overflow-x: hidden` on the `<body>` element as this will prevent horizontal scrolling if fixed-width elements become wider than the page. This is only done for demo purposes.
 
 <div class="exampleWrapper">
   <!-- AURO-GENERATED-CONTENT:START (FILE:src=./../apiExamples/fullBleed.html) -->
@@ -201,6 +201,18 @@ To enable the slideshow to show a preview of the previous and next slides, use t
   <span slot="trigger">See code</span>
 
 <!-- AURO-GENERATED-CONTENT:START (CODE:src=./../apiExamples/fullBleed.html) -->
+<!-- AURO-GENERATED-CONTENT:END -->
+
+</auro-accordion>
+
+<div class="exampleWrapper">
+  <!-- AURO-GENERATED-CONTENT:START (FILE:src=./../apiExamples/fullBleedAutoScroll.html) -->
+  <!-- AURO-GENERATED-CONTENT:END -->
+</div>
+<auro-accordion alignRight>
+  <span slot="trigger">See code</span>
+
+<!-- AURO-GENERATED-CONTENT:START (CODE:src=./../apiExamples/fullBleedAutoScroll.html) -->
 <!-- AURO-GENERATED-CONTENT:END -->
 
 </auro-accordion>

--- a/docs/partials/api.md
+++ b/docs/partials/api.md
@@ -186,3 +186,21 @@ To set a custom aria-label for the play/pause button, pass in new values to the 
 <!-- AURO-GENERATED-CONTENT:END -->
 
 </auro-accordion>
+
+### Full-Bleed Preview
+
+To enable the slideshow to show a preview of the previous and next slides, use the `fullBleed` attribute. This will unhide the overflow of the view area. 
+
+**Note:** To use this properly, a parent container MUST have `overflow-x: hidden` to prevent horizontal scrolling on the page. 
+
+<div class="exampleWrapper">
+  <!-- AURO-GENERATED-CONTENT:START (FILE:src=./../apiExamples/fullBleed.html) -->
+  <!-- AURO-GENERATED-CONTENT:END -->
+</div>
+<auro-accordion alignRight>
+  <span slot="trigger">See code</span>
+
+<!-- AURO-GENERATED-CONTENT:START (CODE:src=./../apiExamples/fullBleed.html) -->
+<!-- AURO-GENERATED-CONTENT:END -->
+
+</auro-accordion>

--- a/src/auro-slideshow.js
+++ b/src/auro-slideshow.js
@@ -31,6 +31,7 @@ import styleCss from "./style.scss";
  * with several options such as autoplay, navigation controls, and pagination dots.
  *
  * @slot - Default slot for the slides. Each child element will be treated as a slide.
+ * @attr fullBleed - If set, the slideshow will take up the width of its parent container showing previous and next slides. **Note:** a parent container must have `overflow-x: hidden` to prevent horizontal scrolling.
  * @csspart prev-button - Use to style the previous button control.
  * @csspart next-button - Use to style the next button control.
  * @csspart play-pause-button - Use to style the play/pause button control.

--- a/src/style.scss
+++ b/src/style.scss
@@ -29,6 +29,11 @@
   padding: var(--border-size);
 }
 
+/* A parent container MUST have `overflow-x: hidden`!! */
+:host([fullBleed]) .slideshow-wrapper {
+  overflow: visible;
+}
+
 .embla {
   max-width: 100%;
   margin: 0;

--- a/src/style.scss
+++ b/src/style.scss
@@ -64,6 +64,10 @@
   }
 }
 
+:host([autoScroll]) .embla__slide {
+  filter: unset;
+}
+
 // ==== Controls ====
 
 .scroll-prev,

--- a/src/style.scss
+++ b/src/style.scss
@@ -52,6 +52,8 @@
   box-sizing: border-box;
   margin-right: 1rem;
   overflow: hidden;
+  filter: brightness(100%);
+  transition: filter 0.7s ease-in-out;
 
   &:focus-visible {
     outline: unset;
@@ -60,7 +62,7 @@
   }
 
   &:not(.active):not(.in-view) {
-    filter: brightness(30%);
+    filter: brightness(65%);
   }
 }
 


### PR DESCRIPTION
# Alaska Airlines Pull Request

Adds ability for full-bleed preview slides using an attribute.
Caveat: A parent of `auro-slideshow` must have `overflow-x: hidden` in order to prevent horizontal scrolling of the page.

There still needs to be some work done to render the looped slides before they enter the viewport. Embla doesn't render them until they intersect the slideshow-wrapper.

**Demo link:**
https://auro-slideshow-32.surge.sh/api
Full-bleed examples are at the bottom of the page. 

Tested changes in test site and it works.

Screenshots:
<img width="1583" height="958" alt="image" src="https://github.com/user-attachments/assets/f1661393-b677-49bc-afe7-37058012d2ab" />
<img width="1583" height="748" alt="image" src="https://github.com/user-attachments/assets/21786b3a-d288-4643-9915-40f72b1840f0" />


## Checklist:

- [x] My update follows the CONTRIBUTING guidelines of this project
- [x] I have performed a self-review of my own update

**By submitting this Pull Request, I confirm that my contribution is made under the terms of the Apache 2.0 license.**

_Pull Requests will be evaluated by their quality of update and whether it is consistent with the goals and values of this project. Any submission is to be considered a conversation between the submitter and the maintainers of this project and may require changes to your submission._

**Thank you for your submission!**<br>
-- Auro Design System Team

## Summary by Sourcery

Add full-bleed preview capability to auro-slideshow using a fullBleed attribute, accompanying CSS, and updated documentation.

New Features:
- Enable full-bleed preview of adjacent slides via fullBleed attribute.

Enhancements:
- Add CSS rule to make slideshow-wrapper overflow visible when fullBleed is set.

Documentation:
- Add fullBleed attribute description to API reference and docs partials with usage notes.
- Provide a fullBleed example file demonstrating side previews.