### PR TITLE
Update slide transition and docs

### DIFF
--- a/README.md
+++ b/README.md
@@ -23,17 +23,22 @@ The following sections are editable by making changes to the following files:
 <!-- The below content is automatically added from ./docs/partials/description.md -->
 `<auro-slideshow>` is an [HTML custom element](https://developer.mozilla.org/en-US/docs/Web/Web_Components/Using_custom_elements) for the purpose of displaying a sequence of slides, which can automatically advance through the content or be manually controlled by the user. 
 
-The `<auro-slideshow>` component is a wrapper element. All slides are slotted content and must be direct children of the component. 
+The `<auro-slideshow>` component is a wrapper element. All slides are slotted content and must be direct children of the component. Slides must have assigned `width` and `height` properties to display properly.
 
 `<auro-slideshow>` is a fully customizable component and does not come with any features turned on by default. The features of `<auro-slideshow>` are turned on by including the proper attributes on the element.
 <!-- AURO-GENERATED-CONTENT:END -->
 <!-- AURO-GENERATED-CONTENT:START (FILE:src=./docs/partials/readmeAddlInfo.md) -->
 <!-- The below content is automatically added from ./docs/partials/readmeAddlInfo.md -->
+
+###  Properties usage
+
 `autoplay` and `autoScroll` are mutually exclusive properties and should not be used together on the same component instance. 
 
-On mobile devices, `autoScroll` and `navigation` controls are automatically disabled.
-
 Both `navigation` and `pagination` can be used together, but at least one must be used to give users a clear way to control the slides manually.
+
+### Mobile behavior
+
+On mobile devices, `autoScroll` and `navigation` controls are automatically disabled. Users can navigate the slideshow by swiping left or right.
 <!-- AURO-GENERATED-CONTENT:END -->
 
 ## UI development browser support

--- a/demo/api.html
+++ b/demo/api.html
@@ -16,7 +16,7 @@
   <head>
     <meta charset="UTF-8" />
     <meta name="viewport" content="width=device-width, initial-scale=1.0" />
-    <title>Auro Web Component Demo | auro-slideshow custom element</title>
+    <title>Auro Web Component Demo | auro-slideshow</title>
 
     <!-- Prism.js Stylesheet -->
     <link rel="stylesheet" type="text/css" href="https://cdn.jsdelivr.net/npm/prismjs@1.24.1/themes/prism.css"/>

--- a/demo/api.html
+++ b/demo/api.html
@@ -16,13 +16,21 @@
   <head>
     <meta charset="UTF-8" />
     <meta name="viewport" content="width=device-width, initial-scale=1.0" />
-    <title>Auro Web Component Generator | auro-slideshow custom element</title>
-    <link
-      rel="stylesheet"
-      type="text/css"
-      href="https://cdn.jsdelivr.net/npm/prismjs@1.24.1/themes/prism.css"
-    />
-    <link rel="stylesheet" href="https://cdn.jsdelivr.net/npm/@aurodesignsystem/design-tokens@latest/dist/auro-classic/CSSCustomProperties.css">
+    <title>Auro Web Component Demo | auro-slideshow custom element</title>
+
+    <!-- Prism.js Stylesheet -->
+    <link rel="stylesheet" type="text/css" href="https://cdn.jsdelivr.net/npm/prismjs@1.24.1/themes/prism.css"/>
+
+    <!-- Legacy reference is still needed to support auro-slideshow's use of legacy token values at this time -->
+    <link rel="stylesheet" type="text/css" href="https://cdn.jsdelivr.net/npm/@aurodesignsystem/design-tokens@latest/dist/legacy/auro-classic/CSSCustomProperties.css"/>
+
+    <!-- Design Token Alaska Theme -->
+    <link rel="stylesheet" type="text/css" href="https://cdn.jsdelivr.net/npm/@aurodesignsystem/design-tokens@latest/dist/themes/alaska/CSSCustomProperties--alaska.min.css"/>
+
+    <!-- Webcore Stylesheet Alaska Theme -->
+    <link rel="stylesheet" type="text/css" href="https://cdn.jsdelivr.net/npm/@aurodesignsystem/webcorestylesheets@latest/dist/bundled/themes/alaska.global.min.css" />
+
+    <!-- Demo Specific Styles -->
     <link rel="stylesheet" type="text/css" href="https://cdn.jsdelivr.net/npm/@aurodesignsystem/webcorestylesheets@latest/dist/demoWrapper.css" />
     <link rel="stylesheet" type="text/css" href="https://cdn.jsdelivr.net/npm/@aurodesignsystem/webcorestylesheets@latest/dist/elementDemoStyles.css" />
   </head>

--- a/demo/index.html
+++ b/demo/index.html
@@ -16,13 +16,21 @@
   <head>
     <meta charset="UTF-8" />
     <meta name="viewport" content="width=device-width, initial-scale=1.0" />
-    <title>Auro Web Component Generator | auro-slideshow custom element</title>
-    <link
-      rel="stylesheet"
-      type="text/css"
-      href="https://cdn.jsdelivr.net/npm/prismjs@1.24.1/themes/prism.css"
-    />
-    <link rel="stylesheet" href="https://cdn.jsdelivr.net/npm/@aurodesignsystem/design-tokens@latest/dist/auro-classic/CSSCustomProperties.css">
+    <title>Auro Web Component Demo | auro-slideshow</title>
+    
+    <!-- Prism.js Stylesheet -->
+    <link rel="stylesheet" type="text/css" href="https://cdn.jsdelivr.net/npm/prismjs@1.24.1/themes/prism.css"/>
+
+    <!-- Legacy reference is still needed to support auro-layover's use of legacy token values at this time -->
+    <link rel="stylesheet" type="text/css" href="https://cdn.jsdelivr.net/npm/@aurodesignsystem/design-tokens@latest/dist/legacy/auro-classic/CSSCustomProperties.css"/>
+
+    <!-- Design Token Alaska Theme -->
+    <link rel="stylesheet" type="text/css" href="https://cdn.jsdelivr.net/npm/@aurodesignsystem/design-tokens@latest/dist/themes/alaska/CSSCustomProperties--alaska.min.css"/>
+    
+    <!-- Webcore Stylesheet Alaska Theme -->
+    <link rel="stylesheet" type="text/css" href="https://cdn.jsdelivr.net/npm/@aurodesignsystem/webcorestylesheets@latest/dist/bundled/themes/alaska.global.min.css" />
+    
+    <!-- Demo Specific Styles -->
     <link rel="stylesheet" type="text/css" href="https://cdn.jsdelivr.net/npm/@aurodesignsystem/webcorestylesheets@latest/dist/demoWrapper.css" />
     <link rel="stylesheet" type="text/css" href="https://cdn.jsdelivr.net/npm/@aurodesignsystem/webcorestylesheets@latest/dist/elementDemoStyles.css" />
   </head>

--- a/docs/partials/description.md
+++ b/docs/partials/description.md
@@ -1,5 +1,5 @@
 `<auro-slideshow>` is an [HTML custom element](https://developer.mozilla.org/en-US/docs/Web/Web_Components/Using_custom_elements) for the purpose of displaying a sequence of slides, which can automatically advance through the content or be manually controlled by the user. 
 
-The `<auro-slideshow>` component is a wrapper element. All slides are slotted content and must be direct children of the component. 
+The `<auro-slideshow>` component is a wrapper element. All slides are slotted content and must be direct children of the component. Slides must have assigned `width` and `height` properties to display properly.
 
 `<auro-slideshow>` is a fully customizable component and does not come with any features turned on by default. The features of `<auro-slideshow>` are turned on by including the proper attributes on the element. 

--- a/docs/partials/readmeAddlInfo.md
+++ b/docs/partials/readmeAddlInfo.md
@@ -1,6 +1,9 @@
+###  Properties usage
 
 `autoplay` and `autoScroll` are mutually exclusive properties and should not be used together on the same component instance. 
 
-On mobile devices, `autoScroll` and `navigation` controls are automatically disabled.
-
 Both `navigation` and `pagination` can be used together, but at least one must be used to give users a clear way to control the slides manually.
+
+### Mobile behavior
+
+On mobile devices, `autoScroll` and `navigation` controls are automatically disabled. Users can navigate the slideshow by swiping left or right.

--- a/src/auro-slideshow.js
+++ b/src/auro-slideshow.js
@@ -267,7 +267,7 @@ export class AuroSlideshow extends LitElement {
    */
   initializeEmbla() {
     const emblaNode = this.shadowRoot.querySelector(".embla");
-    const options = { loop: this.loop, align: "start", inViewThreshold: 0.9 };
+    const options = { loop: this.loop, align: "start", inViewThreshold: 0.5 };
 
     const classNamesOptions = {
       snapped: "active",

--- a/src/auro-slideshow.js
+++ b/src/auro-slideshow.js
@@ -267,7 +267,7 @@ export class AuroSlideshow extends LitElement {
    */
   initializeEmbla() {
     const emblaNode = this.shadowRoot.querySelector(".embla");
-    const options = { loop: this.loop, align: "start" };
+    const options = { loop: this.loop, align: "start", inViewThreshold: 0.9 };
 
     const classNamesOptions = {
       snapped: "active",

--- a/src/style.scss
+++ b/src/style.scss
@@ -61,7 +61,7 @@
       0 0 0 var(--border-size) var(--ds-advanced-color-state-focused, v.$ds-advanced-color-state-focused);
   }
 
-  &:not(.active):not(.in-view) {
+  &:not(.in-view) {
     filter: brightness(65%);
   }
 }

--- a/src/style.scss
+++ b/src/style.scss
@@ -6,6 +6,8 @@
 /* stylelint-disable */
 
 @use "@aurodesignsystem/design-tokens/dist/themes/alaska/SCSSVariables--alaska" as v;
+// Import type classes
+@use '@aurodesignsystem/webcorestylesheets/dist/bundled/type/classes.alaska.min.css';
 
 :host {
   --border-size: 6px; /* Tokenize */

--- a/src/style.scss
+++ b/src/style.scss
@@ -53,7 +53,7 @@
   margin-right: 1rem;
   overflow: hidden;
   filter: brightness(100%);
-  transition: filter 0.7s ease-in-out;
+  transition: filter 0.5s ease-in-out;
 
   &:focus-visible {
     outline: unset;


### PR DESCRIPTION
# Alaska Airlines Pull Request

Please test by going to the Full Bleed Preview section at the bottom of https://auro-slideshow-39.surge.sh/api 
I updated the timing of the slide getting darker when it becomes inactive. You can compare with the current version here: https://auro.alaskaair.com/components/auro/slideshow/api

I also updated some documentation.

## Checklist:

- [x] My update follows the CONTRIBUTING guidelines of this project
- [x] I have performed a self-review of my own update

**By submitting this Pull Request, I confirm that my contribution is made under the terms of the Apache 2.0 license.**

_Pull Requests will be evaluated by their quality of update and whether it is consistent with the goals and values of this project. Any submission is to be considered a conversation between the submitter and the maintainers of this project and may require changes to your submission._

**Thank you for your submission!**<br>
-- Auro Design System Team

## Summary by Sourcery

Update slideshow styling, configuration, demo styling, and documentation for Alaska theme support and improved usage guidelines.

Enhancements:
- Demo pages updated to load Alaska theme stylesheets, legacy tokens, and Prism.js styling
- Documentation refined to require slide dimensions, clarify property usage, and define mobile navigation behavior
- Style definitions tweaked to import Alaska type classes, shorten slide brightness transition, and simplify in-view brightness filter
- Slideshow initialization enhanced by adding an embla inViewThreshold option