### PR TITLE
Add animation delay to allow accurate transform animation on safari

### DIFF
--- a/src/style.scss
+++ b/src/style.scss
@@ -12,6 +12,7 @@
 :host {
   --border-size: 6px; /* Tokenize */
   --border-radius: 24px; /* Tokenize */
+  --dot-animation-time: 0.3s; /* Tokenize */
 }
 
 .container {
@@ -123,7 +124,7 @@
   mix-blend-mode: multiply;
   position: relative;
   cursor: pointer;
-  transition: all 0.3s ease-in-out;
+  transition: all var(--dot-animation-time) ease-in-out;
 
   &:hover:not(.embla__dot--selected) {
     background-color: var(--ds-advanced-color-button-primary-background-inactive-hover, v.$ds-advanced-color-button-primary-background-inactive-hover);
@@ -166,7 +167,7 @@
   cursor: pointer;
   align-self: center;
   justify-self: center;
-  transition: all 0.3s ease-in-out;
+  transition: all var(--dot-animation-time) ease-in-out;
 
    &:hover:not(.stopped) {
     background-color: var(--ds-advanced-color-button-primary-background-inactive-hover, v.$ds-advanced-color-button-primary-background-inactive-hover);
@@ -181,7 +182,7 @@
   top: 0;
   bottom: 0;
   left: -100%;
-  animation-delay: 0.3s;
+  animation-delay: var(--dot-animation-time);
   animation-name: autoplay-progress;
   animation-timing-function: linear;
   animation-iteration-count: 1;

--- a/src/style.scss
+++ b/src/style.scss
@@ -181,6 +181,7 @@
   top: 0;
   bottom: 0;
   left: -100%;
+  animation-delay: 0.3s;
   animation-name: autoplay-progress;
   animation-timing-function: linear;
   animation-iteration-count: 1;


### PR DESCRIPTION
# Alaska Airlines Pull Request

Added a delay to the animation that matches the delay of the dot-to-bar transformation so the animation calculates after it is a bar.

## Checklist:

- [x] My update follows the CONTRIBUTING guidelines of this project
- [x] I have performed a self-review of my own update

**By submitting this Pull Request, I confirm that my contribution is made under the terms of the Apache 2.0 license.**

_Pull Requests will be evaluated by their quality of update and whether it is consistent with the goals and values of this project. Any submission is to be considered a conversation between the submitter and the maintainers of this project and may require changes to your submission._

**Thank you for your submission!**<br>
-- Auro Design System Team

## Summary by Sourcery

Bug Fixes:
- Add a 0.3s animation delay to the autoplay-progress bar to match the dot-to-bar transformation on Safari