### PR TITLE
Pre-rendering of looped slides #37

### DIFF
--- a/apiExamples/fullBleedAutoScroll.html
+++ b/apiExamples/fullBleedAutoScroll.html
@@ -15,6 +15,15 @@
     <div style="height: 480px; max-width: 400px;">
       <img style="object-fit: cover;" src="https://picsum.photos/400/480?random=5" alt="Random image 5">
     </div> 
+    <div style="height: 480px; max-width: 400px;">
+      <img style="object-fit: cover;" src="https://picsum.photos/400/480?random=6" alt="Random image 6">
+    </div> 
+    <div style="height: 480px; max-width: 400px;">
+      <img style="object-fit: cover;" src="https://picsum.photos/400/480?random=7" alt="Random image 7">
+    </div> 
+    <div style="height: 480px; max-width: 400px;">
+      <img style="object-fit: cover;" src="https://picsum.photos/400/480?random=8" alt="Random image 8">
+    </div> 
   </auro-slideshow>
   <!-- For demo purposes only -->
   <style>

--- a/docs/api.md
+++ b/docs/api.md
@@ -1,11 +1,5 @@
 # auro-slideshow
 
-## Attributes
-
-| Attribute   | Description                                      |
-|-------------|--------------------------------------------------|
-| `fullBleed` | If set, the slideshow will take up the width of its parent container showing previous and next slides. **Note:** a parent container must have `overflow-x: hidden` to prevent horizontal scrolling. |
-
 ## Properties
 
 | Property      | Attribute     | Type      | Default           | Description                                      |
@@ -13,6 +7,7 @@
 | `autoScroll`  | `autoScroll`  | `boolean` | false             | If true, the slideshow will scroll continuously. |
 | `autoplay`    | `autoplay`    | `boolean` | false             | If true, the slideshow will play automatically.  |
 | `delay`       | `delay`       | `number`  | 7000              | Slide duration in milliseconds. (Only used with `autoplay`) |
+| `fullBleed`   | `fullBleed`   | `boolean` | false             | If set, the slideshow will take up the width of its parent container showing previous and next slides. **Note:** a parent container must have `overflow-x: hidden` to prevent horizontal scrolling. |
 | `loop`        | `loop`        | `boolean` | false             | If true, the slideshow will loop back to the first slide after reaching the last slide. |
 | `navigation`  | `navigation`  | `boolean` | false             | If true, the slideshow will display navigation arrows for previous and next slides when the slide container is hovered. |
 | `pagination`  | `pagination`  | `boolean` | false             | If true, the slideshow will display pagination dots for each slide. If autoplay is on, the active dot will also show a progress bar. |

--- a/docs/partials/api.md
+++ b/docs/partials/api.md
@@ -205,6 +205,10 @@ To enable the slideshow to show a preview of the previous and next slides, use t
 
 </auro-accordion>
 
+### Full-Bleed + AutoScroll Preview
+
+ There must be enough slides to trigger looping. If all the slides can fit on the page `autoscroll` will not enable.
+
 <div class="exampleWrapper">
   <!-- AURO-GENERATED-CONTENT:START (FILE:src=./../apiExamples/fullBleedAutoScroll.html) -->
   <!-- AURO-GENERATED-CONTENT:END -->

--- a/src/auro-slideshow.js
+++ b/src/auro-slideshow.js
@@ -283,10 +283,10 @@ export class AuroSlideshow extends LitElement {
 
   /**
    * Calculate the difference between the left edge of the slideshow-wrapper and the embla container
-   * @returns offset in pixels
+   * @returns a callback function that returns the offset in pixels
    */
   get _customAlign() {
-    if (!this.fullBleed) return 0;
+    if (!this.fullBleed) return () => 0;
 
     if (this._slideshowWrapperNode) {
       return () =>
@@ -294,7 +294,7 @@ export class AuroSlideshow extends LitElement {
         this._slideshowPaddingSize;
     }
 
-    return 0;
+    return () => 0;
   }
 
   /**
@@ -302,9 +302,11 @@ export class AuroSlideshow extends LitElement {
    * @returns {void}
    */
   _createWidthProp = () => {
-    const width = this._slideshowWrapperNode.getBoundingClientRect().width;
+    if (this._slideshowWrapperNode) {
+      const { width } = this._slideshowWrapperNode.getBoundingClientRect();
 
-    this.style.setProperty("--slideshow-width", `${width}px`);
+      this.style.setProperty("--slideshow-width", `${width}px`);
+    }
   };
 
   /**

--- a/src/auro-slideshow.js
+++ b/src/auro-slideshow.js
@@ -31,7 +31,6 @@ import styleCss from "./style.scss";
  * with several options such as autoplay, navigation controls, and pagination dots.
  *
  * @slot - Default slot for the slides. Each child element will be treated as a slide.
- * @attr fullBleed - If set, the slideshow will take up the width of its parent container showing previous and next slides. **Note:** a parent container must have `overflow-x: hidden` to prevent horizontal scrolling.
  * @csspart prev-button - Use to style the previous button control.
  * @csspart next-button - Use to style the next button control.
  * @csspart play-pause-button - Use to style the play/pause button control.
@@ -54,6 +53,8 @@ export class AuroSlideshow extends LitElement {
 
     this.playLabel = "Play slideshow";
     this.pauseLabel = "Pause slideshow";
+
+    this.fullBleed = false;
 
     /** @private */
     this.playBtnLabel = this.playLabel;
@@ -190,6 +191,13 @@ export class AuroSlideshow extends LitElement {
       isPlaying: {
         type: Boolean,
       },
+      /**
+       * If set, the slideshow will take up the width of its parent container showing previous and next slides. **Note:** a parent container must have `overflow-x: hidden` to prevent horizontal scrolling.
+       */
+      fullBleed: {
+        type: Boolean,
+        reflect: true,
+      },
     };
   }
 
@@ -215,6 +223,18 @@ export class AuroSlideshow extends LitElement {
 
   get _progressNode() {
     return this.shadowRoot.querySelector(".embla__progress");
+  }
+
+  get _slideshowWrapperNode() {
+    return this.shadowRoot.querySelector(".slideshow-wrapper");
+  }
+
+  get _slideshowPaddingSize() {
+    return (
+      Number.parseFloat(
+        getComputedStyle(this._slideshowWrapperNode).paddingLeft,
+      ) || 0
+    );
   }
 
   // ========== PUBLIC METHODS =================
@@ -262,12 +282,42 @@ export class AuroSlideshow extends LitElement {
   // ========== PRIVATE METHODS =================
 
   /**
+   * Calculate the difference between the left edge of the slideshow-wrapper and the embla container
+   * @returns offset in pixels
+   */
+  get _customAlign() {
+    if (!this.fullBleed) return 0;
+
+    if (this._slideshowWrapperNode) {
+      return () =>
+        this._slideshowWrapperNode.getBoundingClientRect().left +
+        this._slideshowPaddingSize;
+    }
+
+    return 0;
+  }
+
+  /**
+   * Calculate the width of the slideshow-wrapper and attach a css property to the host element '--slideshow-width'
+   * @returns {void}
+   */
+  _createWidthProp = () => {
+    const width = this._slideshowWrapperNode.getBoundingClientRect().width;
+
+    this.style.setProperty("--slideshow-width", `${width}px`);
+  };
+
+  /**
    * @private
    * Initializes the Embla carousel with the provided options and plugins.
    */
   initializeEmbla() {
     const emblaNode = this.shadowRoot.querySelector(".embla");
-    const options = { loop: this.loop, align: "start", inViewThreshold: 0.5 };
+    const options = {
+      loop: this.loop,
+      align: this.fullBleed ? this._customAlign : "start",
+      inViewThreshold: 0.5
+    };
 
     const classNamesOptions = {
       snapped: "active",
@@ -335,6 +385,12 @@ export class AuroSlideshow extends LitElement {
         .on("autoScroll:stop", this.togglePlayButtonOnStop)
         .on("autoScroll:play", this.togglePlayButtonOnPlay)
         .on("init", this.togglePlayButtonOnStop);
+    }
+
+    if (this.fullBleed) {
+      this.embla
+        .on("init", this._createWidthProp)
+        .on("resize", this._createWidthProp);
     }
   }
 

--- a/src/style.scss
+++ b/src/style.scss
@@ -33,11 +33,6 @@
   box-sizing: border-box;
 }
 
-/* A parent container MUST have `overflow-x: hidden`!! */
-:host([fullBleed]) .slideshow-wrapper {
-  overflow: visible;
-}
-
 .embla {
   max-width: 100%;
   margin: 0;
@@ -216,5 +211,28 @@
 
   .embla__slide {
     margin-right: var(--slide-spacing);
+  }
+}
+
+/* A parent container MUST have `overflow-x: hidden`!! */
+:host([fullBleed]) {
+  .slideshow-wrapper {
+    overflow: visible;
+  }
+
+  .embla {
+    width: 100vw;
+    position: relative;
+    left: 50%;
+    transform: translateX(-50%);
+    max-width: none; /* Important */
+  }
+
+  .embla__slide {
+    max-width: calc(var(--slideshow-width) - calc(var(--border-size) * 2));
+
+    &:not(.active) {
+      filter: brightness(65%);
+    }
   }
 }

--- a/src/style.scss
+++ b/src/style.scss
@@ -230,7 +230,11 @@
 
   .embla__slide {
     max-width: calc(var(--slideshow-width) - var(--border-size) * 2);
+  }
+}
 
+:host([fullBleed]:not([autoscroll])) {
+  .embla__slide {
     &:not(.active) {
       filter: brightness(65%);
     }

--- a/src/style.scss
+++ b/src/style.scss
@@ -229,7 +229,7 @@
   }
 
   .embla__slide {
-    max-width: calc(var(--slideshow-width) - calc(var(--border-size) * 2));
+    max-width: calc(var(--slideshow-width) - var(--border-size) * 2);
 
     &:not(.active) {
       filter: brightness(65%);


### PR DESCRIPTION
# Alaska Airlines Pull Request

Expanded the rendered area to enable true looping and created custom alignment of the starting slide to retain "left alignment" with perceived container.

## Checklist:

- [x] My update follows the CONTRIBUTING guidelines of this project
- [x] I have performed a self-review of my own update

**By submitting this Pull Request, I confirm that my contribution is made under the terms of the Apache 2.0 license.**

_Pull Requests will be evaluated by their quality of update and whether it is consistent with the goals and values of this project. Any submission is to be considered a conversation between the submitter and the maintainers of this project and may require changes to your submission._

**Thank you for your submission!**<br>
-- Auro Design System Team

## Summary by Sourcery

Implement a fullBleed mode for the slideshow to support true looping with adjacent slide previews by adding a new attribute, computing custom alignment and dynamic width, updating CSS styles, and enhancing documentation.

New Features:
- Add fullBleed attribute to expand the slideshow to full viewport and preview adjacent slides
- Enable true looping by pre-rendering slide clones with custom alignment and dynamic width

Enhancements:
- Introduce helper getters for slideshow wrapper node, padding size, and custom alignment
- Update Embla initialization to use custom alignment when fullBleed is enabled
- Adjust SCSS to position the slideshow wrapper, set slide widths, and style non-active slides in fullBleed mode

Documentation:
- Move fullBleed into the properties table in API docs and add a Full-Bleed + AutoScroll Preview example