### PR TITLE
perf: use `appearance` instead of `ondark` on auro-button #55

### DIFF
--- a/src/auro-slideshow.js
+++ b/src/auro-slideshow.js
@@ -810,7 +810,7 @@ export class AuroSlideshow extends LitElement {
         aria-label="${this.runtimeUtils.getSlotText(this, "ariaLabel.scroll.left") || "Previous slide"}" 
         class="scroll-prev"
         shape="circle"
-        onDark
+        appearance="inverse"
         size="lg"
         @click=${() => this.handleNavClick("prev")}
         part="prev-button">
@@ -820,7 +820,7 @@ export class AuroSlideshow extends LitElement {
         aria-label="${this.runtimeUtils.getSlotText(this, "ariaLabel.scroll.right") || "Next slide"}"
         class="scroll-next"
         shape="circle"
-        onDark
+        appearance="inverse"
         size="lg"
         @click=${() => this.handleNavClick("next")}
         part="next-button">


### PR DESCRIPTION
# Alaska Airlines Pull Request

Replace `ondark` with `appearance="inverse"` on navigation buttons

closes #55 

## Checklist:

- [x] My update follows the CONTRIBUTING guidelines of this project
- [x] I have performed a self-review of my own update

**By submitting this Pull Request, I confirm that my contribution is made under the terms of the Apache 2.0 license.**

_Pull Requests will be evaluated by their quality of update and whether it is consistent with the goals and values of this project. Any submission is to be considered a conversation between the submitter and the maintainers of this project and may require changes to your submission._

**Thank you for your submission!**<br>
-- Auro Design System Team

## Summary by Sourcery

Update the navigation buttons in the AuroSlideshow component to use the new appearance API instead of the deprecated `ondark` attribute.

Enhancements:
- Replace `ondark` attribute with `appearance="inverse"` on the previous slide button
- Replace `ondark` attribute with `appearance="inverse"` on the next slide button